### PR TITLE
Add hybrid binaural engine with dual-band support

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -381,6 +381,35 @@ body.fullscreen #info {
     display: none;
 }
 
+/* Fullscreen uses native API, override for actual fullscreen */
+#rsvp-container:fullscreen,
+#rsvp-container:-webkit-full-screen {
+    width: 100vw;
+    height: 100vh;
+    background: #000;
+}
+
+/* Landscape hint for mobile in portrait */
+body.fullscreen #rsvp-container::after {
+    content: '↻ Rotate for best experience';
+    position: absolute;
+    bottom: 60px;
+    left: 50%;
+    transform: translateX(-50%);
+    color: var(--muted-color);
+    font-size: 0.9rem;
+    opacity: 0.7;
+    pointer-events: none;
+    white-space: nowrap;
+}
+
+/* Hide landscape hint in actual landscape or on desktop */
+@media (orientation: landscape), (min-width: 768px) {
+    body.fullscreen #rsvp-container::after {
+        display: none;
+    }
+}
+
 /* Responsive */
 @media (max-width: 600px) {
     #word-container {

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
             <details>
                 <summary>About SpeedWashing</summary>
                 <p>Words flash one at a time with a red letter marking the Optimal Recognition Point - where your eye should fixate. At high speeds, conscious analysis can't keep up. The words just go in.</p>
-                <p>Use <code>@wpm</code>, <code>@spiral</code>, <code>@subliminals</code>, <code>@snap</code>, <code>@binaural</code>, and <code>@noise</code> commands in scripts. Press F for fullscreen, Space to play/pause.</p>
+                <p>Use <code>@wpm</code>, <code>@spiral</code>, <code>@subliminals</code>, <code>@snap</code>, <code>@binaural</code>, <code>@binaural2</code>, and <code>@noise</code> commands in scripts. Press F for fullscreen, Space to play/pause.</p>
                 <p><a href="https://github.com/EcstasyEngineer/speedwashing">GitHub</a> · <a href="https://github.com/EcstasyEngineer/speedwashing#script-commands">Script Commands</a></p>
             </details>
         </div>
@@ -78,6 +78,7 @@
     <script src="js/spiral.js"></script>
     <script src="js/subliminals.js"></script>
     <script src="js/binaural.js"></script>
+    <script src="js/binaural2.js"></script>
     <script src="js/noise.js"></script>
     <script src="js/rsvp.js"></script>
     <script src="js/app.js"></script>

--- a/js/app.js
+++ b/js/app.js
@@ -44,7 +44,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Track audio state for pause/resume
     let audioState = {
         binaural: { active: false, carrier: 300, beat: 10, volume: 0 },
-        binaural2: { active: false, carrier1: 312.5, beat1: 5, carrier2: null, beat2: null, volume: 0, isoRate: 0, band2Mix: 0.5 },
+        binaural2: { active: false, carrier1: 312.5, beat1: 5, carrier2: null, beat2: null, volume: 0, iso: false, interleave: 0, band2Mix: 0.5 },
         noise: { active: false, volume: 0 }
     };
 
@@ -249,7 +249,8 @@ Thank you again for watching, and I will see you in the next one.`;
                         fade: params.fade,
                         fadeIn: params.fadeIn,
                         volume: params.volume,
-                        isoRate: params.isoRate,
+                        iso: params.iso,
+                        interleave: params.interleave,
                         band2Mix: params.band2Mix
                     }
                 );
@@ -260,7 +261,8 @@ Thank you again for watching, and I will see you in the next one.`;
                     carrier2: params.carrier2,
                     beat2: params.beat2,
                     volume: params.volume,
-                    isoRate: params.isoRate,
+                    iso: params.iso,
+                    interleave: params.interleave,
                     band2Mix: params.band2Mix
                 };
             }

--- a/js/app.js
+++ b/js/app.js
@@ -38,11 +38,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Initialize audio engines
     const binaural = new BinauralEngine();
+    const binaural2 = new HybridBinauralEngine();
     const noise = new NoiseEngine();
 
     // Track audio state for pause/resume
     let audioState = {
         binaural: { active: false, carrier: 300, beat: 10, volume: 0 },
+        binaural2: { active: false, carrier1: 312.5, beat1: 5, carrier2: null, beat2: null, volume: 0, isoRate: 0, band2Mix: 0.5 },
         noise: { active: false, volume: 0 }
     };
 
@@ -127,6 +129,7 @@ Thank you again for watching, and I will see you in the next one.`;
             updatePlayButton(false);
             // Auto-stop audio effects
             binaural.stop(2);
+            binaural2.stop(2);
             noise.stop(2);
         },
         onStateChange: (playing) => {
@@ -134,6 +137,7 @@ Thank you again for watching, and I will see you in the next one.`;
             if (!playing && !isSnapPause) {
                 // Pause - fade out but keep state (skip if snap pause)
                 binaural.stop(0.5);
+                binaural2.stop(0.5);
                 noise.stop(0.5);
             } else if (playing) {
                 // Resume - restore audio if it was active (and not already playing)
@@ -145,6 +149,21 @@ Thank you again for watching, and I will see you in the next one.`;
                         0.5,  // fade for freq changes
                         0.5,  // fadeIn - quick resume
                         audioState.binaural.volume
+                    );
+                }
+                if (audioState.binaural2.active && audioState.binaural2.volume > 0 && !binaural2.isPlaying) {
+                    binaural2.start(
+                        audioState.binaural2.carrier1,
+                        audioState.binaural2.beat1,
+                        audioState.binaural2.carrier2,
+                        audioState.binaural2.beat2,
+                        {
+                            fade: 0.5,
+                            fadeIn: 0.5,
+                            volume: audioState.binaural2.volume,
+                            isoRate: audioState.binaural2.isoRate,
+                            band2Mix: audioState.binaural2.band2Mix
+                        }
                     );
                 }
                 if (audioState.noise.active && audioState.noise.volume > 0 && !noise.isPlaying) {
@@ -216,6 +235,36 @@ Thank you again for watching, and I will see you in the next one.`;
                 };
             }
         },
+        onBinaural2: (args) => {
+            const params = HybridBinauralEngine.parseCommand(args);
+            if (params.action === 'off') {
+                binaural2.stop(params.fade);
+                audioState.binaural2.active = false;
+                audioState.binaural2.volume = 0;
+            } else {
+                binaural2.start(
+                    params.carrier1, params.beat1,
+                    params.carrier2, params.beat2,
+                    {
+                        fade: params.fade,
+                        fadeIn: params.fadeIn,
+                        volume: params.volume,
+                        isoRate: params.isoRate,
+                        band2Mix: params.band2Mix
+                    }
+                );
+                audioState.binaural2 = {
+                    active: true,
+                    carrier1: params.carrier1,
+                    beat1: params.beat1,
+                    carrier2: params.carrier2,
+                    beat2: params.beat2,
+                    volume: params.volume,
+                    isoRate: params.isoRate,
+                    band2Mix: params.band2Mix
+                };
+            }
+        },
         onNoise: (args) => {
             const params = NoiseEngine.parseCommand(args);
             if (params.action === 'off') {
@@ -271,9 +320,11 @@ Thank you again for watching, and I will see you in the next one.`;
         spiral.stop(0.3);
         subliminals.stop(0.3);
         binaural.stop(0.3);
+        binaural2.stop(0.3);
         noise.stop(0.3);
         // Reset audio state
         audioState.binaural = { active: false, carrier: 300, beat: 10, volume: 0 };
+        audioState.binaural2 = { active: false, carrier1: 312.5, beat1: 5, carrier2: null, beat2: null, volume: 0, isoRate: 0, band2Mix: 0.5 };
         audioState.noise = { active: false, volume: 0 };
         rsvp.restart();
     });
@@ -325,9 +376,11 @@ Thank you again for watching, and I will see you in the next one.`;
             spiral.stop(0.3);
             subliminals.stop(0.3);
             binaural.stop(0.3);
+            binaural2.stop(0.3);
             noise.stop(0.3);
             // Reset audio state
             audioState.binaural = { active: false, carrier: 300, beat: 10, volume: 0 };
+            audioState.binaural2 = { active: false, carrier1: 312.5, beat1: 5, carrier2: null, beat2: null, volume: 0, isoRate: 0, band2Mix: 0.5 };
             audioState.noise = { active: false, volume: 0 };
             rsvp.load(text);
             loadedScript = scriptEditor.value;

--- a/js/app.js
+++ b/js/app.js
@@ -44,7 +44,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Track audio state for pause/resume
     let audioState = {
         binaural: { active: false, carrier: 300, beat: 10, volume: 0 },
-        binaural2: { active: false, carrier1: 312.5, beat1: 5, carrier2: null, beat2: null, volume: 0, iso: false, interleave: 0, band2Mix: 0.5 },
+        binaural2: { active: false, carrier1: 312.5, beat1: 5, carrier2: null, beat2: null, volume: 0, interleave: 0, band2Mix: 0.5 },
         noise: { active: false, volume: 0 }
     };
 
@@ -161,7 +161,7 @@ Thank you again for watching, and I will see you in the next one.`;
                             fade: 0.5,
                             fadeIn: 0.5,
                             volume: audioState.binaural2.volume,
-                            isoRate: audioState.binaural2.isoRate,
+                            interleave: audioState.binaural2.interleave,
                             band2Mix: audioState.binaural2.band2Mix
                         }
                     );
@@ -249,7 +249,6 @@ Thank you again for watching, and I will see you in the next one.`;
                         fade: params.fade,
                         fadeIn: params.fadeIn,
                         volume: params.volume,
-                        iso: params.iso,
                         interleave: params.interleave,
                         band2Mix: params.band2Mix
                     }
@@ -261,7 +260,6 @@ Thank you again for watching, and I will see you in the next one.`;
                     carrier2: params.carrier2,
                     beat2: params.beat2,
                     volume: params.volume,
-                    iso: params.iso,
                     interleave: params.interleave,
                     band2Mix: params.band2Mix
                 };
@@ -326,7 +324,7 @@ Thank you again for watching, and I will see you in the next one.`;
         noise.stop(0.3);
         // Reset audio state
         audioState.binaural = { active: false, carrier: 300, beat: 10, volume: 0 };
-        audioState.binaural2 = { active: false, carrier1: 312.5, beat1: 5, carrier2: null, beat2: null, volume: 0, isoRate: 0, band2Mix: 0.5 };
+        audioState.binaural2 = { active: false, carrier1: 312.5, beat1: 5, carrier2: null, beat2: null, volume: 0, interleave: 0, band2Mix: 0.5 };
         audioState.noise = { active: false, volume: 0 };
         rsvp.restart();
     });
@@ -445,7 +443,7 @@ Thank you again for watching, and I will see you in the next one.`;
             noise.stop(0.3);
             // Reset audio state
             audioState.binaural = { active: false, carrier: 300, beat: 10, volume: 0 };
-            audioState.binaural2 = { active: false, carrier1: 312.5, beat1: 5, carrier2: null, beat2: null, volume: 0, isoRate: 0, band2Mix: 0.5 };
+            audioState.binaural2 = { active: false, carrier1: 312.5, beat1: 5, carrier2: null, beat2: null, volume: 0, interleave: 0, band2Mix: 0.5 };
             audioState.noise = { active: false, volume: 0 };
             rsvp.load(text);
             loadedScript = scriptEditor.value;

--- a/js/binaural.js
+++ b/js/binaural.js
@@ -101,56 +101,123 @@ class BinauralEngine {
         this.ctx = null;
         this.node = null;
         this.isPlaying = false;
+        this.useOscillators = false;  // Fallback mode for iOS
+        this.oscL = null;
+        this.oscR = null;
+        this.gainNode = null;
     }
 
     async init() {
         if (this.ctx) return;
         this.ctx = new (window.AudioContext || window.webkitAudioContext)();
-        const blob = new Blob([workletCode], { type: 'application/javascript' });
-        const url = URL.createObjectURL(blob);
-        await this.ctx.audioWorklet.addModule(url);
-        URL.revokeObjectURL(url);
-        this.node = new AudioWorkletNode(this.ctx, 'binaural-processor', {
-            outputChannelCount: [2]
-        });
-        this.node.connect(this.ctx.destination);
+
+        // Try AudioWorklet first, fall back to OscillatorNode for iOS compatibility
+        try {
+            // Use data URL instead of blob URL for better iOS compatibility
+            const dataUrl = 'data:application/javascript;base64,' + btoa(workletCode);
+            await this.ctx.audioWorklet.addModule(dataUrl);
+            this.node = new AudioWorkletNode(this.ctx, 'binaural-processor', {
+                outputChannelCount: [2]
+            });
+            this.node.connect(this.ctx.destination);
+        } catch (e) {
+            console.log('AudioWorklet not supported, using oscillator fallback');
+            this.useOscillators = true;
+            this._initOscillators();
+        }
+    }
+
+    _initOscillators() {
+        // Fallback: use native OscillatorNodes (works everywhere including iOS)
+        this.gainNode = this.ctx.createGain();
+        this.gainNode.gain.value = 0;
+
+        // Create stereo output via channel merger
+        this.merger = this.ctx.createChannelMerger(2);
+
+        this.oscL = this.ctx.createOscillator();
+        this.oscR = this.ctx.createOscillator();
+        this.oscL.type = 'sine';
+        this.oscR.type = 'sine';
+        this.oscL.frequency.value = 295;
+        this.oscR.frequency.value = 305;
+
+        // Left osc -> left channel, Right osc -> right channel
+        const gainL = this.ctx.createGain();
+        const gainR = this.ctx.createGain();
+        this.oscL.connect(gainL);
+        this.oscR.connect(gainR);
+        gainL.connect(this.merger, 0, 0);
+        gainR.connect(this.merger, 0, 1);
+
+        this.merger.connect(this.gainNode);
+        this.gainNode.connect(this.ctx.destination);
+
+        this.oscL.start();
+        this.oscR.start();
     }
 
     async start(carrier = 300, beat = 10, fade = 2, fadeIn = null, volume = 0.3) {
         await this.init();
         if (this.ctx.state === 'suspended') await this.ctx.resume();
-        // If we're off (isPlaying=false), use fadeIn for volume. If already on, use fade.
+
+        const freqL = carrier - beat / 2;
+        const freqR = carrier + beat / 2;
         const gainFade = this.isPlaying ? fade : (fadeIn !== null ? fadeIn : fade);
-        this.node.port.postMessage({
-            freqL: carrier - beat / 2,
-            freqR: carrier + beat / 2,
-            gain: Math.min(0.8, volume),
-            freqSmooth: fade,
-            gainSmooth: gainFade
-        });
+        const targetGain = Math.min(0.8, volume);
+
+        if (this.useOscillators) {
+            // Oscillator fallback mode
+            const now = this.ctx.currentTime;
+            this.oscL.frequency.setTargetAtTime(freqL, now, fade * 0.3);
+            this.oscR.frequency.setTargetAtTime(freqR, now, fade * 0.3);
+            this.gainNode.gain.setTargetAtTime(targetGain, now, gainFade * 0.3);
+        } else {
+            this.node.port.postMessage({
+                freqL, freqR,
+                gain: targetGain,
+                freqSmooth: fade,
+                gainSmooth: gainFade
+            });
+        }
         this.isPlaying = true;
     }
 
     setFrequencies(carrier, beat, seconds = 2) {
-        if (!this.node) return;
-        this.node.port.postMessage({
-            freqL: carrier - beat / 2,
-            freqR: carrier + beat / 2,
-            freqSmooth: seconds
-        });
+        const freqL = carrier - beat / 2;
+        const freqR = carrier + beat / 2;
+
+        if (this.useOscillators) {
+            if (!this.oscL) return;
+            const now = this.ctx.currentTime;
+            this.oscL.frequency.setTargetAtTime(freqL, now, seconds * 0.3);
+            this.oscR.frequency.setTargetAtTime(freqR, now, seconds * 0.3);
+        } else {
+            if (!this.node) return;
+            this.node.port.postMessage({ freqL, freqR, freqSmooth: seconds });
+        }
     }
 
     fadeTo(volume, seconds = 2) {
-        if (!this.node) return;
-        this.node.port.postMessage({
-            gain: Math.min(0.8, Math.max(0, volume)),
-            gainSmooth: seconds
-        });
+        const targetGain = Math.min(0.8, Math.max(0, volume));
+
+        if (this.useOscillators) {
+            if (!this.gainNode) return;
+            this.gainNode.gain.setTargetAtTime(targetGain, this.ctx.currentTime, seconds * 0.3);
+        } else {
+            if (!this.node) return;
+            this.node.port.postMessage({ gain: targetGain, gainSmooth: seconds });
+        }
     }
 
     stop(fade = 2) {
-        if (!this.node) return;
-        this.node.port.postMessage({ gain: 0, gainSmooth: fade });
+        if (this.useOscillators) {
+            if (!this.gainNode) return;
+            this.gainNode.gain.setTargetAtTime(0, this.ctx.currentTime, fade * 0.3);
+        } else {
+            if (!this.node) return;
+            this.node.port.postMessage({ gain: 0, gainSmooth: fade });
+        }
         this.isPlaying = false;
     }
 

--- a/js/binaural2.js
+++ b/js/binaural2.js
@@ -1,0 +1,385 @@
+/**
+ * Hybrid Binaural Engine (binaural2.js)
+ *
+ * Dual-band binaural with optional isochronic modulation.
+ * Supports two independent carrier/beat pairs that create harmonic relationships.
+ *
+ * Usage:
+ *   binaural2 [carrier1] [beat1] [carrier2] [beat2] [options]
+ *   binaural2 off
+ *
+ * Options:
+ *   vol:N       - Volume 0-0.8 (default 0.15)
+ *   fade:N      - Crossfade time in seconds (default 2)
+ *   fadeIn:N    - Initial fade in time (default: same as fade)
+ *   iso:N       - Isochronic pulse rate in Hz (0 = off, default)
+ *   mix:N       - Band 2 mix level 0-1 (default 0.5)
+ *
+ * Examples:
+ *   binaural2 312.5 5              - Single band at 312.5Hz with 5Hz beat
+ *   binaural2 312.5 5 61.7 3.25    - Dual band: high 312.5/5Hz, low 61.7/3.25Hz
+ *   binaural2 312.5 5 61.7 3.25 iso:5   - Same with 5Hz isochronic pulse
+ *   binaural2 off                  - Fade out and stop
+ */
+
+const hybridWorkletCode = `
+class HybridBinauralProcessor extends AudioWorkletProcessor {
+    constructor() {
+        super();
+
+        // Wavetable (shared for all oscillators)
+        this.tableSize = 4096;
+        this.table = new Float32Array(this.tableSize + 1);
+        for (let i = 0; i <= this.tableSize; i++) {
+            this.table[i] = Math.sin((i / this.tableSize) * Math.PI * 2);
+        }
+
+        // Band 1 (high) - phases and frequencies
+        this.phase1L = 0;
+        this.phase1R = 0;
+        this.freq1L = 310;
+        this.freq1R = 315;
+        this.targetFreq1L = 310;
+        this.targetFreq1R = 315;
+
+        // Band 2 (low) - phases and frequencies
+        this.phase2L = 0;
+        this.phase2R = 0;
+        this.freq2L = 60;
+        this.freq2R = 63.25;
+        this.targetFreq2L = 60;
+        this.targetFreq2R = 63.25;
+
+        // Band 2 enabled and mix level
+        this.band2Enabled = false;
+        this.band2Mix = 0.5;
+        this.targetBand2Mix = 0.5;
+
+        // Isochronic modulation
+        this.isoPhase = 0;
+        this.isoRate = 0;  // 0 = disabled
+        this.targetIsoRate = 0;
+
+        // Gain control
+        this.gain = 0;
+        this.gainStart = 0;
+        this.gainEnd = 0;
+        this.gainRampSamples = 0;
+        this.gainRampProgress = 0;
+
+        // Smoothing
+        this.freqSmooth = 0.01;
+
+        this.port.onmessage = (e) => {
+            const d = e.data;
+
+            // Band 1 frequencies
+            if (d.freq1L !== undefined) this.targetFreq1L = d.freq1L;
+            if (d.freq1R !== undefined) this.targetFreq1R = d.freq1R;
+
+            // Band 2 frequencies
+            if (d.freq2L !== undefined) this.targetFreq2L = d.freq2L;
+            if (d.freq2R !== undefined) this.targetFreq2R = d.freq2R;
+            if (d.band2Enabled !== undefined) this.band2Enabled = d.band2Enabled;
+            if (d.band2Mix !== undefined) this.targetBand2Mix = d.band2Mix;
+
+            // Isochronic rate
+            if (d.isoRate !== undefined) this.targetIsoRate = d.isoRate;
+
+            // Smoothing
+            if (d.freqSmooth !== undefined) this.freqSmooth = d.freqSmooth;
+
+            // Gain with linear ramp
+            if (d.gain !== undefined) {
+                this.gainStart = this.gain;
+                this.gainEnd = Math.max(0, Math.min(1, d.gain));
+                this.gainRampSamples = (d.gainSmooth || 0.01) * sampleRate;
+                this.gainRampProgress = 0;
+            }
+        };
+    }
+
+    // Raised cosine envelope for isochronic modulation (0 to 1)
+    isochronicEnvelope(phase) {
+        return 0.5 * (1 + Math.cos(phase + Math.PI));
+    }
+
+    process(inputs, outputs) {
+        const out = outputs[0];
+        if (!out || !out[0] || !out[1]) return true;
+
+        const L = out[0], R = out[1];
+        const table = this.table;
+        const N = this.tableSize;
+        const scale = N / sampleRate;
+
+        // Frequency smoothing coefficient
+        const fSmooth = 1 - Math.exp(-5 / (sampleRate * Math.max(0.001, this.freqSmooth)));
+        // Slower smoothing for mix and iso rate
+        const slowSmooth = 1 - Math.exp(-2 / (sampleRate * 0.1));
+
+        for (let i = 0; i < L.length; i++) {
+            // Smooth frequency changes
+            this.freq1L += (this.targetFreq1L - this.freq1L) * fSmooth;
+            this.freq1R += (this.targetFreq1R - this.freq1R) * fSmooth;
+            this.freq2L += (this.targetFreq2L - this.freq2L) * fSmooth;
+            this.freq2R += (this.targetFreq2R - this.freq2R) * fSmooth;
+
+            // Smooth mix and iso rate
+            this.band2Mix += (this.targetBand2Mix - this.band2Mix) * slowSmooth;
+            this.isoRate += (this.targetIsoRate - this.isoRate) * slowSmooth;
+
+            // Linear gain ramp
+            if (this.gainRampProgress < this.gainRampSamples) {
+                this.gainRampProgress++;
+                const t = this.gainRampProgress / this.gainRampSamples;
+                this.gain = this.gainStart + (this.gainEnd - this.gainStart) * t;
+            } else {
+                this.gain = this.gainEnd;
+            }
+
+            // Band 1 oscillators (interpolated wavetable lookup)
+            const i1L = this.phase1L | 0, f1L = this.phase1L - i1L;
+            const i1R = this.phase1R | 0, f1R = this.phase1R - i1R;
+            const s1L = table[i1L] + (table[i1L + 1] - table[i1L]) * f1L;
+            const s1R = table[i1R] + (table[i1R + 1] - table[i1R]) * f1R;
+
+            // Band 2 oscillators
+            let s2L = 0, s2R = 0;
+            if (this.band2Enabled) {
+                const i2L = this.phase2L | 0, f2L = this.phase2L - i2L;
+                const i2R = this.phase2R | 0, f2R = this.phase2R - i2R;
+                s2L = table[i2L] + (table[i2L + 1] - table[i2L]) * f2L;
+                s2R = table[i2R] + (table[i2R + 1] - table[i2R]) * f2R;
+            }
+
+            // Mix bands: band1 at full, band2 at mix level
+            let mixL = s1L + s2L * this.band2Mix;
+            let mixR = s1R + s2R * this.band2Mix;
+
+            // Normalize mix to prevent clipping when both bands active
+            if (this.band2Enabled && this.band2Mix > 0) {
+                const normFactor = 1 / (1 + this.band2Mix);
+                mixL *= normFactor;
+                mixR *= normFactor;
+            }
+
+            // Apply isochronic envelope if enabled
+            if (this.isoRate > 0) {
+                const isoEnv = this.isochronicEnvelope(this.isoPhase);
+                mixL *= isoEnv;
+                mixR *= isoEnv;
+            }
+
+            // Apply gain
+            L[i] = mixL * this.gain;
+            R[i] = mixR * this.gain;
+
+            // Advance phases
+            this.phase1L += this.freq1L * scale;
+            this.phase1R += this.freq1R * scale;
+            if (this.phase1L >= N) this.phase1L -= N;
+            if (this.phase1R >= N) this.phase1R -= N;
+
+            if (this.band2Enabled) {
+                this.phase2L += this.freq2L * scale;
+                this.phase2R += this.freq2R * scale;
+                if (this.phase2L >= N) this.phase2L -= N;
+                if (this.phase2R >= N) this.phase2R -= N;
+            }
+
+            // Advance isochronic phase
+            if (this.isoRate > 0) {
+                this.isoPhase += (2 * Math.PI * this.isoRate) / sampleRate;
+                if (this.isoPhase >= 2 * Math.PI) this.isoPhase -= 2 * Math.PI;
+            }
+        }
+        return true;
+    }
+}
+registerProcessor('hybrid-binaural-processor', HybridBinauralProcessor);
+`;
+
+class HybridBinauralEngine {
+    constructor() {
+        this.ctx = null;
+        this.node = null;
+        this.isPlaying = false;
+    }
+
+    async init() {
+        if (this.ctx) return;
+        this.ctx = new (window.AudioContext || window.webkitAudioContext)();
+        const blob = new Blob([hybridWorkletCode], { type: 'application/javascript' });
+        const url = URL.createObjectURL(blob);
+        await this.ctx.audioWorklet.addModule(url);
+        URL.revokeObjectURL(url);
+        this.node = new AudioWorkletNode(this.ctx, 'hybrid-binaural-processor', {
+            outputChannelCount: [2]
+        });
+        this.node.connect(this.ctx.destination);
+    }
+
+    /**
+     * Start or update hybrid binaural
+     * @param {number} carrier1 - Band 1 carrier frequency (Hz)
+     * @param {number} beat1 - Band 1 beat frequency (Hz)
+     * @param {number|null} carrier2 - Band 2 carrier frequency (Hz), null to disable
+     * @param {number|null} beat2 - Band 2 beat frequency (Hz)
+     * @param {object} options - { fade, fadeIn, volume, isoRate, band2Mix }
+     */
+    async start(carrier1 = 312.5, beat1 = 5, carrier2 = null, beat2 = null, options = {}) {
+        const {
+            fade = 2,
+            fadeIn = null,
+            volume = 0.15,
+            isoRate = 0,
+            band2Mix = 0.5
+        } = options;
+
+        await this.init();
+        if (this.ctx.state === 'suspended') await this.ctx.resume();
+
+        const gainFade = this.isPlaying ? fade : (fadeIn !== null ? fadeIn : fade);
+        const band2Enabled = carrier2 !== null && beat2 !== null;
+
+        const msg = {
+            freq1L: carrier1 - beat1 / 2,
+            freq1R: carrier1 + beat1 / 2,
+            band2Enabled: band2Enabled,
+            isoRate: isoRate,
+            band2Mix: band2Mix,
+            gain: Math.min(0.8, volume),
+            freqSmooth: fade,
+            gainSmooth: gainFade
+        };
+
+        if (band2Enabled) {
+            msg.freq2L = carrier2 - beat2 / 2;
+            msg.freq2R = carrier2 + beat2 / 2;
+        }
+
+        this.node.port.postMessage(msg);
+        this.isPlaying = true;
+    }
+
+    /**
+     * Update frequencies without changing other parameters
+     */
+    setFrequencies(carrier1, beat1, carrier2 = null, beat2 = null, seconds = 2) {
+        if (!this.node) return;
+
+        const msg = {
+            freq1L: carrier1 - beat1 / 2,
+            freq1R: carrier1 + beat1 / 2,
+            freqSmooth: seconds
+        };
+
+        if (carrier2 !== null && beat2 !== null) {
+            msg.freq2L = carrier2 - beat2 / 2;
+            msg.freq2R = carrier2 + beat2 / 2;
+            msg.band2Enabled = true;
+        }
+
+        this.node.port.postMessage(msg);
+    }
+
+    /**
+     * Set isochronic pulse rate
+     */
+    setIsoRate(rate) {
+        if (!this.node) return;
+        this.node.port.postMessage({ isoRate: rate });
+    }
+
+    /**
+     * Set band 2 mix level
+     */
+    setBand2Mix(mix) {
+        if (!this.node) return;
+        this.node.port.postMessage({ band2Mix: Math.max(0, Math.min(1, mix)) });
+    }
+
+    /**
+     * Fade volume
+     */
+    fadeTo(volume, seconds = 2) {
+        if (!this.node) return;
+        this.node.port.postMessage({
+            gain: Math.min(0.8, Math.max(0, volume)),
+            gainSmooth: seconds
+        });
+    }
+
+    /**
+     * Stop with fade out
+     */
+    stop(fade = 2) {
+        if (!this.node) return;
+        this.node.port.postMessage({ gain: 0, gainSmooth: fade });
+        this.isPlaying = false;
+    }
+
+    /**
+     * Parse command string for hybrid binaural
+     * Format: [carrier1] [beat1] [carrier2] [beat2] [options...]
+     * Options: vol:N, fade:N, fadeIn:N, iso:N, mix:N
+     */
+    static parseCommand(args) {
+        const parts = args.trim().split(/\s+/);
+        const result = {
+            action: 'on',
+            carrier1: 312.5,
+            beat1: 5,
+            carrier2: null,
+            beat2: null,
+            fade: 2,
+            fadeIn: null,
+            volume: 0.15,
+            isoRate: 0,
+            band2Mix: 0.5
+        };
+
+        if (parts[0] === 'off') {
+            result.action = 'off';
+            return result;
+        }
+
+        let numericIndex = 0;
+        for (const p of parts) {
+            if (p.startsWith('fadeIn:')) {
+                result.fadeIn = parseFloat(p.split(':')[1]) || 2;
+            } else if (p.startsWith('fade:')) {
+                result.fade = parseFloat(p.split(':')[1]) || 2;
+            } else if (p.startsWith('vol:')) {
+                const v = parseFloat(p.split(':')[1]);
+                result.volume = Math.min(0.8, Number.isFinite(v) ? v : 0.15);
+            } else if (p.startsWith('iso:')) {
+                result.isoRate = parseFloat(p.split(':')[1]) || 0;
+            } else if (p.startsWith('mix:')) {
+                const m = parseFloat(p.split(':')[1]);
+                result.band2Mix = Math.min(1, Math.max(0, Number.isFinite(m) ? m : 0.5));
+            } else {
+                const v = parseFloat(p);
+                if (!isNaN(v)) {
+                    switch (numericIndex) {
+                        case 0: result.carrier1 = v; break;
+                        case 1: result.beat1 = v; break;
+                        case 2: result.carrier2 = v; break;
+                        case 3: result.beat2 = v; break;
+                    }
+                    numericIndex++;
+                }
+            }
+        }
+
+        // fadeIn defaults to fade if not specified
+        if (result.fadeIn === null) result.fadeIn = result.fade;
+
+        return result;
+    }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = HybridBinauralEngine;
+}

--- a/js/binaural2.js
+++ b/js/binaural2.js
@@ -205,19 +205,96 @@ class HybridBinauralEngine {
         this.ctx = null;
         this.node = null;
         this.isPlaying = false;
+        this.useOscillators = false;  // Fallback mode for iOS
+        // Oscillator fallback components
+        this.osc1L = null;
+        this.osc1R = null;
+        this.osc2L = null;
+        this.osc2R = null;
+        this.gainNode = null;
+        this.gain2Node = null;
+        this.isoGain = null;
+        this.isoLfo = null;
     }
 
     async init() {
         if (this.ctx) return;
         this.ctx = new (window.AudioContext || window.webkitAudioContext)();
-        const blob = new Blob([hybridWorkletCode], { type: 'application/javascript' });
-        const url = URL.createObjectURL(blob);
-        await this.ctx.audioWorklet.addModule(url);
-        URL.revokeObjectURL(url);
-        this.node = new AudioWorkletNode(this.ctx, 'hybrid-binaural-processor', {
-            outputChannelCount: [2]
-        });
-        this.node.connect(this.ctx.destination);
+
+        // Try AudioWorklet first, fall back to OscillatorNode for iOS compatibility
+        try {
+            const dataUrl = 'data:application/javascript;base64,' + btoa(hybridWorkletCode);
+            await this.ctx.audioWorklet.addModule(dataUrl);
+            this.node = new AudioWorkletNode(this.ctx, 'hybrid-binaural-processor', {
+                outputChannelCount: [2]
+            });
+            this.node.connect(this.ctx.destination);
+        } catch (e) {
+            console.log('AudioWorklet not supported, using oscillator fallback for hybrid');
+            this.useOscillators = true;
+            this._initOscillators();
+        }
+    }
+
+    _initOscillators() {
+        // Fallback: use native OscillatorNodes (works everywhere including iOS)
+        // Note: isochronic modulation not supported in fallback mode
+
+        // Master gain
+        this.gainNode = this.ctx.createGain();
+        this.gainNode.gain.value = 0;
+
+        // Band 2 gain (for mixing)
+        this.gain2Node = this.ctx.createGain();
+        this.gain2Node.gain.value = 0.5;
+
+        // Stereo merger
+        this.merger = this.ctx.createChannelMerger(2);
+
+        // Band 1 oscillators
+        this.osc1L = this.ctx.createOscillator();
+        this.osc1R = this.ctx.createOscillator();
+        this.osc1L.type = 'sine';
+        this.osc1R.type = 'sine';
+        this.osc1L.frequency.value = 310;
+        this.osc1R.frequency.value = 315;
+
+        // Band 2 oscillators
+        this.osc2L = this.ctx.createOscillator();
+        this.osc2R = this.ctx.createOscillator();
+        this.osc2L.type = 'sine';
+        this.osc2R.type = 'sine';
+        this.osc2L.frequency.value = 60;
+        this.osc2R.frequency.value = 63.25;
+
+        // Routing: each band gets its own L/R gains
+        const gain1L = this.ctx.createGain();
+        const gain1R = this.ctx.createGain();
+        const gain2L = this.ctx.createGain();
+        const gain2R = this.ctx.createGain();
+
+        this.osc1L.connect(gain1L);
+        this.osc1R.connect(gain1R);
+        this.osc2L.connect(gain2L);
+        this.osc2R.connect(gain2R);
+
+        // Band 2 goes through mix gain
+        gain2L.connect(this.gain2Node);
+        gain2R.connect(this.gain2Node);
+
+        // Mix to stereo
+        gain1L.connect(this.merger, 0, 0);
+        gain1R.connect(this.merger, 0, 1);
+        this.gain2Node.connect(this.merger, 0, 0);
+        this.gain2Node.connect(this.merger, 0, 1);
+
+        this.merger.connect(this.gainNode);
+        this.gainNode.connect(this.ctx.destination);
+
+        this.osc1L.start();
+        this.osc1R.start();
+        this.osc2L.start();
+        this.osc2R.start();
     }
 
     /**
@@ -242,24 +319,48 @@ class HybridBinauralEngine {
 
         const gainFade = this.isPlaying ? fade : (fadeIn !== null ? fadeIn : fade);
         const band2Enabled = carrier2 !== null && beat2 !== null;
+        const targetGain = Math.min(0.8, volume);
 
-        const msg = {
-            freq1L: carrier1 - beat1 / 2,
-            freq1R: carrier1 + beat1 / 2,
-            band2Enabled: band2Enabled,
-            isoRate: isoRate,
-            band2Mix: band2Mix,
-            gain: Math.min(0.8, volume),
-            freqSmooth: fade,
-            gainSmooth: gainFade
-        };
+        const freq1L = carrier1 - beat1 / 2;
+        const freq1R = carrier1 + beat1 / 2;
+        const freq2L = band2Enabled ? carrier2 - beat2 / 2 : 60;
+        const freq2R = band2Enabled ? carrier2 + beat2 / 2 : 63.25;
 
-        if (band2Enabled) {
-            msg.freq2L = carrier2 - beat2 / 2;
-            msg.freq2R = carrier2 + beat2 / 2;
+        if (this.useOscillators) {
+            // Oscillator fallback mode (no isochronic support)
+            const now = this.ctx.currentTime;
+            const tc = fade * 0.3;
+
+            this.osc1L.frequency.setTargetAtTime(freq1L, now, tc);
+            this.osc1R.frequency.setTargetAtTime(freq1R, now, tc);
+
+            if (band2Enabled) {
+                this.osc2L.frequency.setTargetAtTime(freq2L, now, tc);
+                this.osc2R.frequency.setTargetAtTime(freq2R, now, tc);
+                this.gain2Node.gain.setTargetAtTime(band2Mix * 0.5, now, tc);
+            } else {
+                this.gain2Node.gain.setTargetAtTime(0, now, tc);
+            }
+
+            this.gainNode.gain.setTargetAtTime(targetGain, now, gainFade * 0.3);
+        } else {
+            const msg = {
+                freq1L, freq1R,
+                band2Enabled,
+                isoRate,
+                band2Mix,
+                gain: targetGain,
+                freqSmooth: fade,
+                gainSmooth: gainFade
+            };
+
+            if (band2Enabled) {
+                msg.freq2L = freq2L;
+                msg.freq2R = freq2R;
+            }
+
+            this.node.port.postMessage(msg);
         }
-
-        this.node.port.postMessage(msg);
         this.isPlaying = true;
     }
 
@@ -267,27 +368,38 @@ class HybridBinauralEngine {
      * Update frequencies without changing other parameters
      */
     setFrequencies(carrier1, beat1, carrier2 = null, beat2 = null, seconds = 2) {
-        if (!this.node) return;
+        const freq1L = carrier1 - beat1 / 2;
+        const freq1R = carrier1 + beat1 / 2;
+        const band2Enabled = carrier2 !== null && beat2 !== null;
 
-        const msg = {
-            freq1L: carrier1 - beat1 / 2,
-            freq1R: carrier1 + beat1 / 2,
-            freqSmooth: seconds
-        };
-
-        if (carrier2 !== null && beat2 !== null) {
-            msg.freq2L = carrier2 - beat2 / 2;
-            msg.freq2R = carrier2 + beat2 / 2;
-            msg.band2Enabled = true;
+        if (this.useOscillators) {
+            if (!this.osc1L) return;
+            const now = this.ctx.currentTime;
+            const tc = seconds * 0.3;
+            this.osc1L.frequency.setTargetAtTime(freq1L, now, tc);
+            this.osc1R.frequency.setTargetAtTime(freq1R, now, tc);
+            if (band2Enabled) {
+                this.osc2L.frequency.setTargetAtTime(carrier2 - beat2 / 2, now, tc);
+                this.osc2R.frequency.setTargetAtTime(carrier2 + beat2 / 2, now, tc);
+            }
+        } else {
+            if (!this.node) return;
+            const msg = { freq1L, freq1R, freqSmooth: seconds };
+            if (band2Enabled) {
+                msg.freq2L = carrier2 - beat2 / 2;
+                msg.freq2R = carrier2 + beat2 / 2;
+                msg.band2Enabled = true;
+            }
+            this.node.port.postMessage(msg);
         }
-
-        this.node.port.postMessage(msg);
     }
 
     /**
      * Set isochronic pulse rate
      */
     setIsoRate(rate) {
+        // Not supported in oscillator fallback mode
+        if (this.useOscillators) return;
         if (!this.node) return;
         this.node.port.postMessage({ isoRate: rate });
     }
@@ -296,27 +408,41 @@ class HybridBinauralEngine {
      * Set band 2 mix level
      */
     setBand2Mix(mix) {
-        if (!this.node) return;
-        this.node.port.postMessage({ band2Mix: Math.max(0, Math.min(1, mix)) });
+        const val = Math.max(0, Math.min(1, mix));
+        if (this.useOscillators) {
+            if (!this.gain2Node) return;
+            this.gain2Node.gain.setTargetAtTime(val * 0.5, this.ctx.currentTime, 0.1);
+        } else {
+            if (!this.node) return;
+            this.node.port.postMessage({ band2Mix: val });
+        }
     }
 
     /**
      * Fade volume
      */
     fadeTo(volume, seconds = 2) {
-        if (!this.node) return;
-        this.node.port.postMessage({
-            gain: Math.min(0.8, Math.max(0, volume)),
-            gainSmooth: seconds
-        });
+        const targetGain = Math.min(0.8, Math.max(0, volume));
+        if (this.useOscillators) {
+            if (!this.gainNode) return;
+            this.gainNode.gain.setTargetAtTime(targetGain, this.ctx.currentTime, seconds * 0.3);
+        } else {
+            if (!this.node) return;
+            this.node.port.postMessage({ gain: targetGain, gainSmooth: seconds });
+        }
     }
 
     /**
      * Stop with fade out
      */
     stop(fade = 2) {
-        if (!this.node) return;
-        this.node.port.postMessage({ gain: 0, gainSmooth: fade });
+        if (this.useOscillators) {
+            if (!this.gainNode) return;
+            this.gainNode.gain.setTargetAtTime(0, this.ctx.currentTime, fade * 0.3);
+        } else {
+            if (!this.node) return;
+            this.node.port.postMessage({ gain: 0, gainSmooth: fade });
+        }
         this.isPlaying = false;
     }
 

--- a/js/rsvp.js
+++ b/js/rsvp.js
@@ -24,6 +24,7 @@ class RSVPEngine {
         this.onSubliminals = options.onSubliminals || (() => {});
         this.onSnap = options.onSnap || (() => {});
         this.onBinaural = options.onBinaural || (() => {});
+        this.onBinaural2 = options.onBinaural2 || (() => {});
         this.onNoise = options.onNoise || (() => {});
     }
 
@@ -86,6 +87,16 @@ class RSVPEngine {
                 pendingCommands.push({
                     type: 'binaural',
                     args: binauralMatch[1]
+                });
+                continue;
+            }
+
+            // Check for @binaural2 command (hybrid dual-band)
+            const binaural2Match = trimmed.match(/^@binaural2\s+(.+)/i);
+            if (binaural2Match) {
+                pendingCommands.push({
+                    type: 'binaural2',
+                    args: binaural2Match[1]
                 });
                 continue;
             }
@@ -192,6 +203,8 @@ class RSVPEngine {
                     this.onSnap(cmd.pause);
                 } else if (cmd.type === 'binaural') {
                     this.onBinaural(cmd.args);
+                } else if (cmd.type === 'binaural2') {
+                    this.onBinaural2(cmd.args);
                 } else if (cmd.type === 'noise') {
                     this.onNoise(cmd.args);
                 }


### PR DESCRIPTION
New binaural2.js provides HybridBinauralEngine:
- Dual-band binaural with two carrier/beat pairs
- Optional isochronic envelope modulation (raised cosine)
- Smooth frequency and gain transitions
- Command: @binaural2 [c1] [b1] [c2] [b2] [options]
- Options: vol:, fade:, fadeIn:, iso:, mix:

Ported from HYPNOCLI's Python binaural.py "bambi" mode
to real-time Web Audio API with AudioWorklet.